### PR TITLE
Fix installing sources in test subcommand

### DIFF
--- a/packages/toolchain/src/source-tester.ts
+++ b/packages/toolchain/src/source-tester.ts
@@ -10,8 +10,11 @@ import fs from 'node:fs'
 import {expect} from 'chai'
 
 export interface ISourceTester {
-  installSource?(request: SourceInstallRequest): Promise<void>
   testSource(request: SourceTestRequest, callback: (response: SourceTestResponse) => Promise<void>): Promise<void>
+}
+
+export interface ISourceInstaller {
+  installSource(request: SourceInstallRequest): Promise<void>
 }
 
 declare type TestCase = (testCase: string, runner: () => Promise<void>) => Promise<void>
@@ -145,11 +148,11 @@ export class SourceTester implements ISourceTester {
   }
 }
 
-export class OnDeviceSourceTester implements ISourceTester {
+export class OnDeviceSourceTester implements ISourceTester, ISourceInstaller {
   // eslint-disable-next-line no-useless-constructor
   constructor(private grpcClient: PaperbackSourceTesterClient) {}
 
-  async installSources(request: SourceInstallRequest): Promise<void> {
+  async installSource(request: SourceInstallRequest): Promise<void> {
     await new Promise((resolve, reject) => {
       this.grpcClient.installSource(
         request,


### PR DESCRIPTION
Basically, the implementation had a misnamed method and it wasn't caught because the method is optional in the interface. Instead of using an optional method, create a separate interface for installing and implement that, which ensures the method is named correctly at compile time.