### PR TITLE
Some small visibility improved

### DIFF
--- a/packages/toolchain/src/commands/bundle.ts
+++ b/packages/toolchain/src/commands/bundle.ts
@@ -165,7 +165,7 @@ export default class Bundle extends Command {
         }
 
         // Write the JSON payload to file
-        fs.writeFileSync(path.join(directoryPath, 'versioning.json'), JSON.stringify(jsonObject))
+        fs.writeFileSync(path.join(directoryPath, 'versioning.json'), JSON.stringify(jsonObject, null, 2))
     }
 
     async run() {

--- a/packages/toolchain/src/homepage/index.html
+++ b/packages/toolchain/src/homepage/index.html
@@ -43,7 +43,7 @@
 
 <body onload="bodyOnLoad()">
     <header>
-        <img class="icon" src="https://paperback.moe/icons/logo.svg" alt="Repository logo" />
+        <img class="icon" src="https://paperback.moe/pb-logo.svg" alt="Repository logo" />
         <h1 id="repositoryName"></h1>
         <p class="pageDescription">A Paperback extensions repository</p><a class="addToPaperbackButton"
             onclick="addToPaperback()">Add


### PR DESCRIPTION
two items : 

- logo was not displayed
- using stringify(<json>, null, 2) => will print the versioning file with line break and indent, that way it's easier to compare new versions (on gh-pages for example)