### PR TITLE
Better Deno runtime support and cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "paperback-toolchain",
+  "name": "paperback-monorepo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "paperback-toolchain",
+      "name": "paperback-monorepo",
       "workspaces": [
         "packages/*"
       ],
@@ -3922,6 +3922,7 @@
       "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.2.tgz",
       "integrity": "sha512-eQcKyrEcDYeZJKu4vUWiu0ii/1Gfev6GF4FsLSgNez5/+aQyAUCjg3ZWlurf491WiYZTXCWyKAxyPWk8DKv2MA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^4.3.2",
         "ansis": "^3.17.0",
@@ -4004,6 +4005,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4236,6 +4238,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5711,6 +5714,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5789,6 +5793,7 @@
       "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.1",
         "@typescript-eslint/types": "8.39.1",
@@ -6088,6 +6093,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7644,17 +7650,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -7859,6 +7854,7 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13779,6 +13775,7 @@
       "version": "4.0.2",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14030,6 +14027,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -16419,6 +16417,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16641,6 +16640,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17267,7 +17267,7 @@
     "packages/runtime-polyfills": {
       "name": "@paperback/runtime-polyfills",
       "version": "1.0.0-alpha.57",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "entities": "^6.0.1",
         "user-agents": "^1.1.635"
@@ -17315,7 +17315,7 @@
         "ts-node": "^10.9.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "packages/toolchain/node_modules/buffer": {
@@ -17345,7 +17345,7 @@
     "packages/types": {
       "name": "@paperback/types",
       "version": "1.0.0-alpha.57",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "chai": "^5.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "paperback-toolchain",
-  "description": "Paperback Toolchain",
+  "name": "paperback-monorepo",
+  "description": "Monorepo for the Paperback toolchain, types and runtime polyfills",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/runtime-polyfills/package.json
+++ b/packages/runtime-polyfills/package.json
@@ -1,24 +1,32 @@
 {
   "name": "@paperback/runtime-polyfills",
+  "description": "Node runtime polyfills to test Paperback extensions",
+  "keywords": [
+    "paperback",
+    "runtime",
+    "polyfills"
+  ],
+  "author": "Faizan Durrani",
+  "homepage": "https://paperback.moe",
+  "repository": "https://github.com/Paperback-iOS/paperback-toolchain",
+  "bugs": "https://github.com/Paperback-iOS/paperback-toolchain/issues",
+  "license": "MIT",
   "version": "1.0.0-alpha.57",
-  "description": "Node runtime polyfills to test Paperback sources",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
-  "type": "module",
   "scripts": {
     "build": "rm -rf ./lib && npx tsc",
     "prepack": "npm run build"
-  },
-  "author": "Faizan Durrani",
-  "license": "ISC",
-  "devDependencies": {
-    "@paperback/types": "*",
-    "@types/user-agents": "^1.0.4"
   },
   "dependencies": {
     "entities": "^6.0.1",
     "user-agents": "^1.1.635"
   },
+  "devDependencies": {
+    "@paperback/types": "*",
+    "@types/user-agents": "^1.0.4"
+  },
+  "type": "module",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolchain/package.json
+++ b/packages/toolchain/package.json
@@ -1,7 +1,23 @@
 {
-  "author": "Faizan Durrani @FaizanDurrani",
-  "bin": {
-    "paperback-cli": "./bin/run.js"
+  "name": "@paperback/toolchain",
+  "description": "Toolchain to build Paperback extensions",
+  "keywords": [
+    "paperback",
+    "toolchain",
+    "oclif"
+  ],
+  "author": "Faizan Durrani",
+  "homepage": "https://paperback.moe",
+  "repository": "https://github.com/Paperback-iOS/paperback-toolchain",
+  "bugs": "https://github.com/Paperback-iOS/paperback-toolchain/issues",
+  "license": "MIT",
+  "version": "1.0.0-alpha.57",
+  "scripts": {
+    "build": "shx rm -rf lib && tsc -b && cp -r src/homepage lib/ && cp -r src/shims lib/",
+    "postpack": "shx rm -f oclif.manifest.json",
+    "prepack": "npm run build && oclif manifest && oclif readme",
+    "test": "mocha --forbid-only \"test/**/*.test.ts\"",
+    "version": "oclif readme && git add README.md"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.13.4",
@@ -17,7 +33,6 @@
     "listr2": "^8.3.3",
     "picocolors": "^1.1.1"
   },
-  "description": "The Paperback extension development toolchain",
   "devDependencies": {
     "@oclif/test": "^4.1.13",
     "@protobuf-ts/plugin": "^2.11.1",
@@ -35,17 +50,19 @@
     "ts-node": "^10.9.2"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
+  },
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "bin": {
+    "paperback-cli": "./bin/run.js"
   },
   "files": [
     "/bin",
     "/lib",
     "/oclif.manifest.json"
   ],
-  "homepage": "https://github.com/FaizanDurrani/paperback-toolchain",
-  "license": "MIT",
-  "main": "lib/index.js",
-  "name": "@paperback/toolchain",
   "oclif": {
     "bin": "paperback-cli",
     "dirname": "paperback-cli",
@@ -56,23 +73,8 @@
     ],
     "topicSeparator": " "
   },
-  "repository": "FaizanDurrani/paperback-toolchain",
-  "type": "module",
-  "scripts": {
-    "build": "shx rm -rf lib && tsc -b && cp -r src/homepage lib/ && cp -r src/shims lib/",
-    "postpack": "shx rm -f oclif.manifest.json",
-    "prepack": "npm run build && oclif manifest && oclif readme",
-    "test": "mocha --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif readme && git add README.md"
-  },
-  "version": "1.0.0-alpha.57",
-  "bugs": "https://github.com/FaizanDurrani/paperback-toolchain/issues",
-  "keywords": [
-    "oclif"
-  ],
-  "types": "lib/index.d.ts",
-  "gitHead": "14158af57f191721407565a300545c36db537a22",
   "ts-node": {
     "esm": true
-  }
+  },
+  "gitHead": "14158af57f191721407565a300545c36db537a22"
 }

--- a/packages/toolchain/src/commands/bundle.ts
+++ b/packages/toolchain/src/commands/bundle.ts
@@ -206,9 +206,22 @@ export async function runTests() {
       path.join(basePath, 'node_modules/@paperback/types/package.json'),
       { with: { type: 'json' } }
     )
-    const projectInfo = await import(path.join(basePath, 'package.json'), {
-      with: { type: 'json' },
-    })
+
+    let projectInfo;
+
+    try {
+      projectInfo = await import(path.join(basePath, 'package.json'), {
+        with: { type: 'json' },
+      })
+    } catch {
+      try {
+        projectInfo = await import(path.join(basePath, 'deno.json'), {
+          with: { type: 'json' },
+        })
+      } catch {
+        throw new Error("No package.json or deno.json was found")
+      }
+    }
 
     const jsonObject = {
       buildTime: new Date(),
@@ -218,7 +231,7 @@ export async function runTests() {
       },
       repository: {
         name:
-          projectInfo.default?.repositoryName ??
+          projectInfo.default?.name ??
           'Paperback Extension Repository',
         description:
           projectInfo.default?.description ??

--- a/packages/toolchain/src/commands/bundle.ts
+++ b/packages/toolchain/src/commands/bundle.ts
@@ -207,7 +207,7 @@ export async function runTests() {
       { with: { type: 'json' } }
     )
 
-    let projectInfo;
+    let projectInfo
 
     try {
       projectInfo = await import(path.join(basePath, 'package.json'), {
@@ -219,7 +219,7 @@ export async function runTests() {
           with: { type: 'json' },
         })
       } catch {
-        throw new Error("No package.json or deno.json was found")
+        throw new Error('No package.json or deno.json was found')
       }
     }
 
@@ -230,9 +230,7 @@ export async function runTests() {
         types: commonsInfo.default.version,
       },
       repository: {
-        name:
-          projectInfo.default?.name ??
-          'Paperback Extension Repository',
+        name: projectInfo.default?.name ?? 'Paperback Extension Repository',
         description:
           projectInfo.default?.description ??
           'An extension repository for Paperback',

--- a/packages/toolchain/src/commands/test.ts
+++ b/packages/toolchain/src/commands/test.ts
@@ -39,7 +39,10 @@ export default class Test extends Command {
     if (args.extension) {
       await new SourceTestRunner(bundlesDir, args.extension).runTests()
     } else {
-      const versioningJson: {sources: (ExtensionInfo & {id: string})[]} = JSON.parse(fs.readFileSync(path.join(bundlesDir, 'versioning.json'), 'utf-8'))
+      const versioningJson: { sources: (ExtensionInfo & { id: string })[] } =
+        JSON.parse(
+          fs.readFileSync(path.join(bundlesDir, 'versioning.json'), 'utf-8')
+        )
       for (const source of versioningJson.sources) {
         await new SourceTestRunner(bundlesDir, source.id).runTests()
       }
@@ -73,9 +76,6 @@ class SourceTestRunner {
       vmContext
     )
 
-    await vm.runInContext(
-      `source.runTests()`,
-      vmContext
-    )
+    await vm.runInContext(`source.runTests()`, vmContext)
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,25 +1,32 @@
 {
   "name": "@paperback/types",
-  "version": "1.0.0-alpha.57",
-  "description": "TypeScript Types for Paperback",
-  "keywords": [],
+  "description": "TypeScript types to build Paperback extensions",
+  "keywords": [
+    "paperback",
+    "types",
+    "typescript"
+  ],
   "author": "Faizan Durrani",
-  "publishConfig": {
-    "access": "public"
-  },
-  "license": "ISC",
-  "type": "module",
+  "homepage": "https://paperback.moe",
+  "repository": "https://github.com/Paperback-iOS/paperback-toolchain",
+  "bugs": "https://github.com/Paperback-iOS/paperback-toolchain/issues",
+  "license": "MIT",
+  "version": "1.0.0-alpha.57",
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "rm -rf ./lib && tsc",
     "prepack": "npm run build"
   },
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
-  "gitHead": "14158af57f191721407565a300545c36db537a22",
   "dependencies": {
     "chai": "^5.3.1"
   },
   "devDependencies": {
     "@types/chai": "^5.2.2"
-  }
+  },
+  "type": "module",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "14158af57f191721407565a300545c36db537a22"
 }

--- a/packages/types/src/impl/Application.ts
+++ b/packages/types/src/impl/Application.ts
@@ -11,16 +11,15 @@ import type { Response, ResponseInterceptor } from '../Response.js'
 import type { Cookie } from '../Cookie.js'
 import type { SelectorID, SelectorRegistry, KeyOfType } from './Selector.js'
 
-
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Application {
     // Global
     const isResourceLimited: boolean
-    
+
     const filterAdultTitles: boolean
     const filterMatureTitles: boolean
-    
+
     function decodeHTMLEntities(str: string): string
     function sleep(seconds: number): Promise<void>
 

--- a/packages/types/src/impl/Extension.ts
+++ b/packages/types/src/impl/Extension.ts
@@ -1,4 +1,4 @@
-import type { MangaProviding } from "./interfaces/MangaProviding.js"
+import type { MangaProviding } from './interfaces/MangaProviding.js'
 
 interface _Extension {
   initialise(): Promise<void>

--- a/packages/types/src/impl/TestDefinition.ts
+++ b/packages/types/src/impl/TestDefinition.ts
@@ -8,7 +8,10 @@ import type { SearchResultItem } from '../SearchResultItem.js'
 import type { SortingOption } from '../SortingOption.js'
 import type { SourceManga } from '../SourceManga.js'
 import type { Extension } from './Extension.js'
-import { implementsChapterProviding, type ChapterProviding } from './interfaces/ChapterProviding.js'
+import {
+  implementsChapterProviding,
+  type ChapterProviding,
+} from './interfaces/ChapterProviding.js'
 import type { MangaProviding } from './interfaces/MangaProviding.js'
 import {
   implementsSearchResultsProviding,
@@ -172,16 +175,11 @@ export const registerDefaultTests = function (
     }
   }
 
-
   registerDefaultMangaProvidingSourceTests(suite, extension, testData)
 
   if (sourceCapabilities & SourceIntents.CHAPTER_PROVIDING) {
     if (implementsChapterProviding(extension)) {
-      registerDefaultChapterProvidingSourceTests(
-        suite,
-        extension,
-        testData
-      )
+      registerDefaultChapterProvidingSourceTests(suite, extension, testData)
     } else {
       throw new Error(
         `extension does not implement 'ChapterProviding' but has the 'CHAPTER_PROVIDING' capability`

--- a/packages/types/src/impl/interfaces/ChapterProviding.ts
+++ b/packages/types/src/impl/interfaces/ChapterProviding.ts
@@ -21,7 +21,7 @@ export interface ChapterProviding extends MangaProviding {
    * chapter in here
    * @param updateManager the update manager which will be responsible for fetching updates, DO NOT STORE THIS
    * @param lastUpdateDate last time the app successfully fetched updates
-   * 
+   *
    * Notes:
    * - If your source needs cloudflare bypass throw a {@link CloudflareError} here
    */
@@ -43,7 +43,7 @@ export interface UpdateManager {
 
   /**
    * Get all chapters for a title from app db
-   * 
+   *
    * This can potentially be a really expensive call, only perform this when you know you'll be saving many requests.
    *
    * In general, avoid doing diffing in the source and let the app handle merging chapters.

--- a/packages/types/src/impl/interfaces/index.ts
+++ b/packages/types/src/impl/interfaces/index.ts
@@ -8,6 +8,9 @@ export * from './SearchResultsProviding.js'
 export * from './SettingsFormProviding.js'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function hasPropertiesOf<T>(properties: (keyof T)[], obj: any): obj is T {
+export function hasPropertiesOf<T>(
+  properties: (keyof T)[],
+  obj: any
+): obj is T {
   return properties.every((k) => k in obj)
 }


### PR DESCRIPTION
- Deno runtime users can now define the repository name and description
  in the `deno.json` file instead.
- Reverted the name key to `name`
- Cleaned all `package.json` files up
- Ran Prettier on the whole project
- Cleaned the `.gitignore` file up